### PR TITLE
Remove superfluous dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-const osHomedir = require('os-homedir');
-const home = osHomedir();
+const os = require('os');
+const home = os.homedir();
 
 module.exports = str => {
 	if (typeof str !== 'string') {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "shell",
     "bash"
   ],
-  "dependencies": {
-    "os-homedir": "^1.0.0"
-  },
   "devDependencies": {
     "ava": "*",
     "xo": "*"


### PR DESCRIPTION
`os.homedir()` is available natively on Node.js 4.0 and up, and this module is only compatible with Node.js 4 and up...