### PR TITLE
Simplified regex to support passthrough $vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,5 +8,5 @@ module.exports = str => {
 		throw new TypeError(`Expected a string, got ${typeof str}`);
 	}
 
-	return home ? str.replace(/^~($|\/|\\)/, `${home}$1`) : str;
+	return home ? str.replace(/^~/, `${home}`) : str;
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const os = require('os');
+
 const home = os.homedir();
 
 module.exports = str => {

--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ module.exports = str => {
 		throw new TypeError(`Expected a string, got ${typeof str}`);
 	}
 
-	/* Only replace if followed by path delimiter or regex variable. */
+	/* Don't replace if tilde not followed by path delimiter or regex variable. */
 	if (/^~[^$$|\\|/]/.test(str)) {
 		return str;
 	}
 
-	/* If valid swap tilde. */
+	/* If valid, swap tilde. */
 	return str.replace(/^~/, `${home}`);
 };

--- a/index.js
+++ b/index.js
@@ -8,5 +8,11 @@ module.exports = str => {
 		throw new TypeError(`Expected a string, got ${typeof str}`);
 	}
 
-	return home ? str.replace(/^~/, `${home}`) : str;
+	/* Only replace if followed by path delimiter or regex variable. */
+	if (/^~[^$$|\\|/]/.test(str)) {
+		return str;
+	}
+
+	/* If valid swap tilde. */
+	return str.replace(/^~/, `${home}`);
 };

--- a/test.js
+++ b/test.js
@@ -14,4 +14,8 @@ test(t => {
 	t.true(/.+\\abc\\def$/.test(m('~\\abc\\def')));
 	t.true(/.+\/abc\\def$/.test(m('~/abc\\def')));
 	t.true(/.+\\abc\/def$/.test(m('~\\abc/def')));
+
+    /* Allow passthrough regex variables. */
+	t.false(/^~\$1$/.test(m('~$1')));
+	t.false(/^~\/\$1$/.test(m('~/$1')));
 });


### PR DESCRIPTION
Addressing: [Issue 5](https://github.com/sindresorhus/untildify/issues/5)

The original regex attempted to capture and reuse the path delimiter after the tilde.

This broke the substitution when a regex variable was used as the base of the path.

works:
* `~/`
* `~/$1`

did not work:

* `~$1`

To fix, I instead replaced only the leading tilde, without regard to subsequent characters.
This is probably more performant (simpler regex, same delimiter reuse), and opens up more use cases.

Note: this will not solve [Issue 1](https://github.com/sindresorhus/untildify/issues/1), 
but should not conflict with a fix more than the original implementation.
the original implementation.