### PR TITLE
Avoid issues with non-ASCII symbols on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,20 @@
 'use strict';
 const os = require('os');
-const home = os.homedir();
+const isWindows = require('is-windows');
+
+const home = (() => {
+	const homeDir = os.homedir();
+	if (isWindows()) {
+		// Return the home directory with the user name part in 8.3 format
+		// (https://goo.gl/FxW2CB) if needed. This is a workaround for
+		// https://github.com/nodejs/node/issues/17586.
+		const tmpDir = os.tmpdir();
+		const userDir = homeDir.replace(/([^\\])+$/g, '');
+		const user83 = tmpDir.slice(userDir.length).replace(/\\.*$/, '');
+		return `${userDir}${user83}`;
+	}
+	return homeDir;
+})();
 
 module.exports = str => {
 	if (typeof str !== 'string') {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
   },
   "xo": {
     "esnext": true
+  },
+  "dependencies": {
+    "is-windows": "^1.0.1"
   }
 }


### PR DESCRIPTION
Using `fs.realpathSync` matches what temp-dir does (https://github.com/sindresorhus/temp-dir/blob/9569a24ba9e5be1bf0eba644f748b9bebbcb083b/index.js#L9) and might just solve https://github.com/GoogleChromeLabs/jsvu/issues/11 based on the screenshot in that issue.