### PR TITLE
Normalize results

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const os = require('os');
+const path = require('path');
 
 const homeDirectory = os.homedir();
 
@@ -8,5 +9,5 @@ module.exports = pathWithTilde => {
 		throw new TypeError(`Expected a string, got ${typeof pathWithTilde}`);
 	}
 
-	return homeDirectory ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory) : pathWithTilde;
+	return homeDirectory ? path.normalize(pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)) : pathWithTilde;
 };


### PR DESCRIPTION
In Windows

```js
const untildify = require('untildify');
 
untildify('~/dev');
//=> 'C:\Users\sindresorhus/dev'
```

I think the normal result should be `'C:\Users\sindresorhus\dev'`

